### PR TITLE
abstract-plugin-manager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5|^4.8",
-        "phing/phing": "^2"
+        "phing/phing": "^2",
+        "zendframework/zend-validator": "^2"
     },
     "autoload": {
         "psr-4": {

--- a/src/EventsCapable/EventsCapableInitializer.php
+++ b/src/EventsCapable/EventsCapableInitializer.php
@@ -4,6 +4,7 @@ namespace abacaphiliac\EventsCapable;
 
 use Zend\EventManager\EventsCapableInterface;
 use Zend\EventManager\ListenerAggregateInterface;
+use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\InitializerInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -20,6 +21,10 @@ class EventsCapableInitializer implements InitializerInterface
     {
         if (!$instance instanceof EventsCapableInterface) {
             return;
+        }
+        
+        if ($serviceLocator instanceof AbstractPluginManager) {
+            $serviceLocator = $serviceLocator->getServiceLocator();
         }
         
         $events = $instance->getEventManager();

--- a/tests/EventsCapable/EventsCapableInitializerTest.php
+++ b/tests/EventsCapable/EventsCapableInitializerTest.php
@@ -6,7 +6,9 @@ use abacaphiliac\EventsCapable\EventsCapableInitializer;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\EventsCapableInterface;
 use Zend\EventManager\ListenerAggregateInterface;
+use Zend\Hydrator\HydratorPluginManager;
 use Zend\ServiceManager\ServiceManager;
+use Zend\Validator\ValidatorPluginManager;
 
 class EventsCapableInitializerTest extends \PHPUnit_Framework_TestCase
 {
@@ -62,5 +64,33 @@ class EventsCapableInitializerTest extends \PHPUnit_Framework_TestCase
         $actual = $this->sut->initialize(new \stdClass(), new ServiceManager());
 
         $this->assertNull($actual);
+    }
+
+    public function testInitializeFromPluginManager()
+    {
+        $events = new EventManager();
+
+        $instance = $this->getMock('\Zend\EventManager\EventsCapableInterface');
+        $instance->method('getEventManager')->willReturn($events);
+
+        $listener = $this->getMock('\Zend\EventManager\ListenerAggregateInterface');
+        $listener->expects($this->once())->method('attach')->with($events);
+
+        $services = new ServiceManager();
+        $services->setService('MyListener', $listener);
+        $services->setService('config', array(
+            'abacaphiliac/events-capable' => array(
+                'eventsCapable' => array(
+                    get_class($instance) => array(
+                        'MyListener',
+                    ),
+                ),
+            ),
+        ));
+        
+        $validators = new ValidatorPluginManager();
+        $validators->setServiceLocator($services);
+
+        $this->sut->initialize($instance, $validators);
     }
 }


### PR DESCRIPTION
 allow this initializer to be added to any plugin-manager config. registered listener services must be provided by service_manager.
