### PR TITLE
listener-instantiation-fallback

### DIFF
--- a/src/EventsCapable/EventsCapableInitializer.php
+++ b/src/EventsCapable/EventsCapableInitializer.php
@@ -49,7 +49,7 @@ class EventsCapableInitializer implements InitializerInterface
         $listeners = $options->getListeners($instance);
         
         foreach ($listeners as $listener) {
-            if (!$listener instanceof ListenerAggregateInterface) {
+            if (is_string($listener)) {
                 $listener = $this->getListener($serviceLocator, $listener);
             }
             


### PR DESCRIPTION
is_string is the more appropriate check to do before invoking service container or instantiation of a class.
