### PR TITLE
listener-instantiation-fallback - wrap call to service manager

### DIFF
--- a/src/EventsCapable/EventsCapableInitializer.php
+++ b/src/EventsCapable/EventsCapableInitializer.php
@@ -2,10 +2,11 @@
 
 namespace abacaphiliac\EventsCapable;
 
-use abacaphiliac\EventsCapable\Exception\UnexpectedValueException;
+use abacaphiliac\EventsCapable\Exception\ListenerNotCreatedException;
 use Zend\EventManager\EventsCapableInterface;
 use Zend\EventManager\ListenerAggregateInterface;
 use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Exception\ExceptionInterface;
 use Zend\ServiceManager\InitializerInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -69,7 +70,11 @@ class EventsCapableInitializer implements InitializerInterface
     private function getListener(ServiceLocatorInterface $serviceLocator, $listenerName)
     {
         if ($serviceLocator->has($listenerName)) {
-            return $serviceLocator->get($listenerName);
+            try {
+                return $serviceLocator->get($listenerName);
+            } catch (ExceptionInterface $e) {
+                throw new ListenerNotCreatedException($e->getMessage(), $e->getCode(), $e);
+            }
         }
         
         // TODO Check for constructor params and throw an exception guiding the dev to register with service container.
@@ -78,6 +83,8 @@ class EventsCapableInitializer implements InitializerInterface
             return new $listenerName;
         }
         
-        throw new UnexpectedValueException('Listener must be registered in service container, or an invokable class.');
+        throw new ListenerNotCreatedException(
+            'Listener must be registered in service container, or an invokable class.'
+        );
     }
 }

--- a/src/EventsCapable/Exception/ListenerNotCreatedException.php
+++ b/src/EventsCapable/Exception/ListenerNotCreatedException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace abacaphiliac\EventsCapable\Exception;
+
+class ListenerNotCreatedException extends \RuntimeException implements ExceptionInterface
+{
+
+}

--- a/src/EventsCapable/Exception/UnexpectedValueException.php
+++ b/src/EventsCapable/Exception/UnexpectedValueException.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace abacaphiliac\EventsCapable\Exception;
-
-class UnexpectedValueException extends \UnexpectedValueException implements ExceptionInterface
-{
-
-}

--- a/tests/EventsCapable/EventsCapableInitializerTest.php
+++ b/tests/EventsCapable/EventsCapableInitializerTest.php
@@ -4,6 +4,7 @@ namespace abacaphiliacTest\EventsCapable;
 
 use abacaphiliac\EventsCapable\EventsCapableInitializer;
 use Zend\EventManager\EventManager;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Validator\ValidatorPluginManager;
 
@@ -142,7 +143,7 @@ class EventsCapableInitializerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \abacaphiliac\EventsCapable\Exception\UnexpectedValueException
+     * @expectedException \abacaphiliac\EventsCapable\Exception\ListenerNotCreatedException
      */
     public function testUnexpectedListenerType()
     {
@@ -157,6 +158,33 @@ class EventsCapableInitializerTest extends \PHPUnit_Framework_TestCase
                 'eventsCapable' => array(
                     get_class($instance) => array(
                         'ClassNameThatDoesNotExist',
+                    ),
+                ),
+            ),
+        ));
+
+        $this->sut->initialize($instance, $services);
+    }
+
+    /**
+     * @expectedException \abacaphiliac\EventsCapable\Exception\ListenerNotCreatedException
+     */
+    public function testServiceManagerFailsToCreateListener()
+    {
+        $events = new EventManager();
+
+        $instance = $this->getMock('\Zend\EventManager\EventsCapableInterface');
+        $instance->method('getEventManager')->willReturn($events);
+
+        $services = new ServiceManager();
+        $services->setFactory('MyListener', function () {
+            throw new ServiceNotCreatedException();
+        });
+        $services->setService('config', array(
+            'abacaphiliac/events-capable' => array(
+                'eventsCapable' => array(
+                    get_class($instance) => array(
+                        'MyListener',
                     ),
                 ),
             ),


### PR DESCRIPTION
listener-instantiation-fallback - wrap call to service manager in try-catch so that service manager exceptions can be wrapped by our lib exception.
